### PR TITLE
Fix search function

### DIFF
--- a/src/Addressbook.php
+++ b/src/Addressbook.php
@@ -336,10 +336,8 @@ class Addressbook extends rcube_addressbook
                 $this->page_size = $pageSizeBackup;
             }
 
-            while (
-                /** @var ?SaveData $save_data */
-                $save_data = $result->next()
-            ) {
+            /** @var ?SaveData $save_data */
+            foreach ($result as $save_data) {
                 if ($this->checkPostSearchFilter($save_data, $required, $allMustMatch, $postSearchFilter, $mode)) {
                     /** @var array{ID: string} $save_data */
                     $ids[] = $save_data["ID"];


### PR DESCRIPTION
The behavior of rcube_result_set->next() was changed upstream. This fixes enumeration within the search() function.

The upstream change is: https://github.com/roundcube/roundcubemail/commit/8133acba689172a8a5f5331e7d4de968f746021f